### PR TITLE
Fixed crash on curl_close, Global Clean Curl on Module Unload

### DIFF
--- a/CFunctions.cpp
+++ b/CFunctions.cpp
@@ -192,8 +192,6 @@ int CFunctions::curl_perform( lua_State* luaVM )
 
 				CURLcode code = curl_easy_perform(pointer->getPointer());
 
-				curl_easy_cleanup(pointer->getPointer());
-
 				if (code != CURLE_OK)
 				{
 					lua_pushlightuserdata(luaVM, (void*)code);

--- a/ml_curl.cpp
+++ b/ml_curl.cpp
@@ -63,6 +63,7 @@ MTAEXPORT bool DoPulse ( void )
 
 MTAEXPORT bool ShutdownModule ( void )
 {
+	curl_global_cleanup();
 	SAFE_DELETE(curlCollection);
     return true;
 }


### PR DESCRIPTION
curl_easy_cleanup can be only executed once, so its impossible to close the curl, because its trys again to clean and crashes
